### PR TITLE
Display author and date on posts

### DIFF
--- a/css/lib/desktop/s-article.css
+++ b/css/lib/desktop/s-article.css
@@ -1,7 +1,7 @@
 /* ARTICLES */
-#content .scene .article .articlebody > p:first-child {padding-top: 36px;}
+#content .scene .article .articlebody > p:first-child,
 #content .scene .article .articlebody > h3:first-child,
-#content .scene .article .articlebody > .c-wrapper:first-child {padding-top: 46px;}
+#content .scene .article .articlebody > .c-wrapper:first-child {padding-top: 36px;}
 
 
 #content .scene .article h1 {}

--- a/css/lib/desktop/s-article.css
+++ b/css/lib/desktop/s-article.css
@@ -1,12 +1,12 @@
 /* ARTICLES */
-#content .scene .article .articlebody > p:first-child,
+#content .scene .article .articlebody > p:first-child {padding-top: 36px;}
 #content .scene .article .articlebody > h3:first-child,
 #content .scene .article .articlebody > .c-wrapper:first-child {padding-top: 46px;}
 
 
 #content .scene .article h1 {}
-#content .scene .article > ul.info {width: 100%; margin: 0 auto; padding-top: 10px; padding-left: 12px; padding-right: 12px; box-sizing: border-box;}
-#content .scene .article > ul.info li {padding-left: 0}
+#content .scene .article > ul.info {display: block; width: 100%; margin: 0 auto; padding: 16px 12px 0 18px;  box-sizing: border-box;}
+#content .scene .article > ul.info li {padding-left: 0; color: #666;}
 #content .scene > .article > .articlebody {/* width: 600px; margin: 0 auto; */} /* Only 600px width if article stands alone (no grid) */
 
 /* TAGS */


### PR DESCRIPTION
Posts had a `ul.info` block with information about author and date that had `display: none` set. I've overridden this, changed the color of the information to be grey, and adjusted the paddings to account for the extra content.